### PR TITLE
fix file seperator for normalizepath in build_lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: texPreview
 Type: Package
 Title: Compile and Preview Snippets of 'LaTeX' in 'RStudio'
-Version: 1.3.0
-Date: 2018-11-09
+Version: 1.3.1
+Date: 2018-01-06
 Authors@R: c(
               person(given = 'Jonathan',family = 'Sidi',email = 'yonis@metrumrg.com',role = c('aut','cre')),
               person(given = 'Daniel',family = 'Polhamus',email = 'danp@metrumrg.com',role = c('aut'))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,5 +28,5 @@ URL: https://github.com/metrumresearchgroup/texPreview
 BugReports: https://github.com/metrumresearchgroup/texPreview/issues
 LazyData: false
 NeedsCompilation: no
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/R/build_lines.R
+++ b/R/build_lines.R
@@ -42,7 +42,7 @@ build_lines <- function(obj,
   
   TMPL <- readLines(system.file('tmpl.tex',package = 'texPreview'))
   
-  input_path <- normalizePath(file.path(fileDir,sprintf('%s.tex',stem)))
+  input_path <- normalizePath(file.path(fileDir,sprintf('%s.tex',stem)),winslash = '/')
   
   ARGS <- append(margin, list(usrPackages = paste0(usrPackages,collapse = '\n'), file = input_path))
   

--- a/R/build_lines.R
+++ b/R/build_lines.R
@@ -42,7 +42,7 @@ build_lines <- function(obj,
   
   TMPL <- readLines(system.file('tmpl.tex',package = 'texPreview'))
   
-  input_path <- normalizePath(file.path(fileDir,sprintf('%s.tex',stem)),winslash = '/')
+  input_path <- normalizePath(file.path(fileDir,sprintf('%s.tex',stem)),winslash = .Platform$file.sep)
   
   ARGS <- append(margin, list(usrPackages = paste0(usrPackages,collapse = '\n'), file = input_path))
   

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://cranlogs.r-pkg.org/badges/texPreview)](https://cran.r-project.org/package=texPreview)
 [![Travis-CI Build Status](https://travis-ci.org/metrumresearchgroup/texPreview.svg?branch=master)](https://travis-ci.org/metrumresearchgroup/texPreview)
 [![Coverage Status](https://img.shields.io/codecov/c/github/metrumresearchgroup/texPreview/master.svg)](https://codecov.io/github/metrumresearchgroup/texPreview?branch=master)
-[![Covrpage Summary](https://img.shields.io/badge/covrpage-Last_Build_2018_11_09-brightgreen.svg)](http://tinyurl.com/ybkr8fsu)
+[![Covrpage Summary](https://img.shields.io/badge/covrpage-Last_Build_2019_01_06-brightgreen.svg)](http://tinyurl.com/ybkr8fsu)
 
 # texPreview
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,32 +1,34 @@
 Tests and Coverage
 ================
-09 November, 2018 15:04:50
+06 January, 2019 08:22:06
 
 This output is created by
-[covrpage](https://github.com/yonicd/covrpage).
+[covrpage](https://github.com/metrumresearchgroup/covrpage).
 
 ## Coverage
 
 Coverage summary is created using the
-[covr](https://github.com/r-lib/covr) package.
+[covr](https://github.com/r-lib/covr)
+package.
 
-| Object                                           | Coverage (%) |
-| :----------------------------------------------- | :----------: |
-| texPreview                                       |    47.27     |
-| [R/opts\_complete.R](../R/opts_complete.R)       |     0.00     |
-| [R/opts.R](../R/opts.R)                          |     5.88     |
-| [R/zzz.R](../R/zzz.R)                            |     8.33     |
-| [R/tex\_addin.R](../R/tex_addin.R)               |    12.50     |
-| [R/get\_texpackages.R](../R/get_texpackages.R)   |    40.00     |
-| [R/tex\_viewer.R](../R/tex_viewer.R)             |    40.91     |
-| [R/tex\_preview.R](../R/tex_preview.R)           |    58.33     |
-| [R/build\_usepackage.R](../R/build_usepackage.R) |    73.33     |
-| [R/tex\_dir\_setup.R](../R/tex_dir_setup.R)      |    78.95     |
-| [R/tex\_image.R](../R/tex_image.R)               |    80.00     |
-| [R/tex\_return.R](../R/tex_return.R)             |    80.00     |
-| [R/build\_lines.R](../R/build_lines.R)           |    100.00    |
-| [R/tex\_build.R](../R/tex_build.R)               |    100.00    |
-| [R/tex\_cleanup.R](../R/tex_cleanup.R)           |    100.00    |
+| Object                                                      | Coverage (%) |
+| :---------------------------------------------------------- | :----------: |
+| texPreview                                                  |    47.27     |
+| [R/opts\_complete.R](../R/opts_complete.R)                  |     0.00     |
+| [R/texPreview-depreciated.R](../R/texPreview-depreciated.R) |     0.00     |
+| [R/opts.R](../R/opts.R)                                     |     5.88     |
+| [R/zzz.R](../R/zzz.R)                                       |     8.33     |
+| [R/tex\_addin.R](../R/tex_addin.R)                          |    12.50     |
+| [R/tex\_viewer.R](../R/tex_viewer.R)                        |    40.91     |
+| [R/get\_texpackages.R](../R/get_texpackages.R)              |    50.00     |
+| [R/tex\_dir\_setup.R](../R/tex_dir_setup.R)                 |    78.95     |
+| [R/tex\_image.R](../R/tex_image.R)                          |    80.00     |
+| [R/tex\_return.R](../R/tex_return.R)                        |    80.00     |
+| [R/build\_usepackage.R](../R/build_usepackage.R)            |    84.62     |
+| [R/build\_lines.R](../R/build_lines.R)                      |    100.00    |
+| [R/tex\_build.R](../R/tex_build.R)                          |    100.00    |
+| [R/tex\_cleanup.R](../R/tex_cleanup.R)                      |    100.00    |
+| [R/tex\_preview.R](../R/tex_preview.R)                      |    100.00    |
 
 <br>
 
@@ -38,8 +40,8 @@ package.
 
 | file                                          | n |  time | error | failed | skipped | warning |
 | :-------------------------------------------- | -: | ----: | ----: | -----: | ------: | ------: |
-| [test-tex.R](testthat/test-tex.R)             | 9 | 0.716 |     0 |      0 |       0 |       0 |
-| [test-utilities.R](testthat/test-utilities.R) | 9 | 0.291 |     0 |      0 |       0 |       0 |
+| [test-tex.R](testthat/test-tex.R)             | 9 | 0.653 |     0 |      0 |       0 |       0 |
+| [test-utilities.R](testthat/test-utilities.R) | 9 | 0.314 |     0 |      0 |       0 |       0 |
 
 <details closed>
 
@@ -48,23 +50,23 @@ package.
 
 | file                                              | context                      | test                                              | status | n |  time |
 | :------------------------------------------------ | :--------------------------- | :------------------------------------------------ | :----- | -: | ----: |
-| [test-tex.R](testthat/test-tex.R#L31)             | core tex function            | porting to tex: files generated                   | PASS   | 1 | 0.003 |
+| [test-tex.R](testthat/test-tex.R#L31)             | core tex function            | porting to tex: files generated                   | PASS   | 1 | 0.002 |
 | [test-tex.R](testthat/test-tex.R#L35)             | core tex function            | porting to tex: class of output                   | PASS   | 1 | 0.001 |
 | [test-tex.R](testthat/test-tex.R#L49)             | core tex function            | porting to tex no filedir: no files generated     | PASS   | 1 | 0.002 |
-| [test-tex.R](testthat/test-tex.R#L53)             | core tex function            | porting to tex no filedir: class of output        | PASS   | 1 | 0.001 |
+| [test-tex.R](testthat/test-tex.R#L53)             | core tex function            | porting to tex no filedir: class of output        | PASS   | 1 | 0.000 |
 | [test-tex.R](testthat/test-tex.R#L67)             | core tex function            | keep pdf as an output: files generated            | PASS   | 1 | 0.002 |
 | [test-tex.R](testthat/test-tex.R#L71)             | core tex function            | keep pdf as an output: class of output            | PASS   | 1 | 0.001 |
-| [test-tex.R](testthat/test-tex.R#L86)             | core tex function            | html output: return magick object                 | PASS   | 1 | 0.701 |
+| [test-tex.R](testthat/test-tex.R#L86)             | core tex function            | html output: return magick object                 | PASS   | 1 | 0.641 |
 | [test-tex.R](testthat/test-tex.R#L115)            | core tex function            | tex lines directly input: validate benchmark      | PASS   | 1 | 0.002 |
-| [test-tex.R](testthat/test-tex.R#L129)            | core tex function            | use svg device: check if file created             | PASS   | 1 | 0.003 |
-| [test-utilities.R](testthat/test-utilities.R#L10) | utility functions of package | build usepackage call: basic call                 | PASS   | 1 | 0.002 |
-| [test-utilities.R](testthat/test-utilities.R#L14) | utility functions of package | build usepackage call: check library is installed | PASS   | 1 | 0.137 |
+| [test-tex.R](testthat/test-tex.R#L129)            | core tex function            | use svg device: check if file created             | PASS   | 1 | 0.002 |
+| [test-utilities.R](testthat/test-utilities.R#L10) | utility functions of package | build usepackage call: basic call                 | PASS   | 1 | 0.001 |
+| [test-utilities.R](testthat/test-utilities.R#L14) | utility functions of package | build usepackage call: check library is installed | PASS   | 1 | 0.145 |
 | [test-utilities.R](testthat/test-utilities.R#L18) | utility functions of package | build usepackage call: add options                | PASS   | 1 | 0.002 |
-| [test-utilities.R](testthat/test-utilities.R#L22) | utility functions of package | build usepackage call: use bad library name       | PASS   | 1 | 0.131 |
-| [test-utilities.R](testthat/test-utilities.R#L40) | utility functions of package | build usepackage multiple calls: class            | PASS   | 1 | 0.002 |
+| [test-utilities.R](testthat/test-utilities.R#L22) | utility functions of package | build usepackage call: use bad library name       | PASS   | 1 | 0.151 |
+| [test-utilities.R](testthat/test-utilities.R#L40) | utility functions of package | build usepackage multiple calls: class            | PASS   | 1 | 0.001 |
 | [test-utilities.R](testthat/test-utilities.R#L44) | utility functions of package | build usepackage multiple calls: dimension        | PASS   | 1 | 0.001 |
-| [test-utilities.R](testthat/test-utilities.R#L56) | utility functions of package | find packages: check class                        | PASS   | 2 | 0.003 |
-| [test-utilities.R](testthat/test-utilities.R#L73) | utility functions of package | empty call to addin: cause addin to crash         | PASS   | 1 | 0.013 |
+| [test-utilities.R](testthat/test-utilities.R#L56) | utility functions of package | find packages: check class                        | PASS   | 2 | 0.002 |
+| [test-utilities.R](testthat/test-utilities.R#L73) | utility functions of package | empty call to addin: cause addin to crash         | PASS   | 1 | 0.011 |
 
 </details>
 
@@ -76,7 +78,7 @@ package.
 | :------- | :---------------------------------- |
 | Version  | R version 3.5.1 (2018-07-02)        |
 | Platform | x86\_64-apple-darwin15.6.0 (64-bit) |
-| Running  | macOS High Sierra 10.13.6           |
+| Running  | macOS 10.14.2                       |
 | Language | en\_US                              |
 | Timezone | America/New\_York                   |
 
@@ -84,7 +86,7 @@ package.
 | :------- | :--------- |
 | testthat | 2.0.0.9000 |
 | covr     | 3.2.0      |
-| covrpage | 0.0.64     |
+| covrpage | 0.0.69     |
 
 </details>
 


### PR DESCRIPTION
PR based on issue: https://github.com/metrumresearchgroup/texPreview/issues/13