### PR TITLE
adjust build_lines and tmpl.tex to work with new CRAN tex compiler

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^revdep$
 ^data-raw$
 ^pkgdown$
+^CRAN-RELEASE$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: texPreview
 Title: Compile and Preview Snippets of 'LaTeX' in 'RStudio'
-Version: 1.4.1
-Date: 2019-10-27
+Version: 1.4.2
+Date: 2019-12-01
 Authors@R: 
     c(person(given = "Jonathan",
              family = "Sidi",

--- a/R/build_lines.R
+++ b/R/build_lines.R
@@ -23,6 +23,8 @@ build_lines <- function(obj,
   
   input_path <- normalizePath(tex_path(fileDir,stem),winslash = .Platform$file.sep)
   
+  input_path <- sprintf('{%s}',input_path)
+  
   ARGS <- append(margin, list(usrPackages = paste0(usrPackages,collapse = '\n'), file = input_path))
   
   whisker::whisker.render(TMPL, ARGS)

--- a/inst/tmpl.tex
+++ b/inst/tmpl.tex
@@ -14,5 +14,5 @@
 \captionsetup{labelformat=empty}
 {{{usrPackages}}}
 \begin{document}
-\input{ {{file}} }
+\input{{{file}}}
 \end{document}


### PR DESCRIPTION
tex compiler/pandoc was changed on CRAN systems causing a failure. Patch to tmpl to remove leading and trailing spaces used with {whisker}. added curly braces in build_lines instead.