### PR TITLE
add TinyTex to PATH for next steps in the job

### DIFF
--- a/.github/workflows/R-win.yml
+++ b/.github/workflows/R-win.yml
@@ -27,9 +27,7 @@ jobs:
         run: |
           install.packages('tinytex')
           tinytex::install_tinytex(extra_packages = c('standalone', 'xcolor', 'booktabs', 'multirow', 'amsmath', 'listings', 'setspace', 'caption', 'graphics', 'tools', 'psnfss', 'varwidth', 'colortbl', 'epstopdf-pkg', 'pgf'))
-          tinytex::tinytex_root()
-          tinytex::use_tinytex(tinytex::tinytex_root())
-          #tinytex::tlmgr_update()
+          cat("::add-path::", tinytex::tinytex_root(), "\\bin\\win32", sep = "")
         shell: Rscript {0}
       
       - run: tlmgr --version


### PR DESCRIPTION
I think only adding this line will do the job. I got error in my test for your full workflow but from a check ERROR.

This is a Special GHA syntax from the documentation: 
https://help.github.com/en/actions/reference/development-tools-for-github-actions#add-a-system-path-add-path

The [recipes in r-lib/actions](https://github.com/r-lib/actions/tree/master/setup-tinytex) does that at the end but I didn't look yet why it is not working. 

Other possible solution: use `tinytex::tlmgr_path("add")` just before doing the checking but I get another error I am not sure to identify.