### PR TITLE
avoid unnecessary negation on nzchar

### DIFF
--- a/R/tex_check.R
+++ b/R/tex_check.R
@@ -57,7 +57,7 @@ check_package <- function(x){
     
   }else{
     
-    if(!nzchar(Sys.which("mpm"))){
+    if(nzchar(Sys.which("mpm"))){
       check_mpm(x)
     }else{
       stop('neither tlmgr or mpm are installed and in %PATH%')


### PR DESCRIPTION
Since presumedly this code path should only be run if `mpm` is indeed on the PATH.